### PR TITLE
Configuring server and client via command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,18 @@ Exports and imports work but only for a single file called `buildingeditortest.j
 
 ---
 
-* Running a server.
-* edit server.py for your specific setup for IP and port.
-* note: disable city gen after the first time you start it. This is a known issue.
-* `python ./server.py`
+**Running a server**
 
-* Running a client.
-* edit client.py to point to the server ip and address.
-* `python ./client.py firstname lastname`
+* note: disable city gen after the first time you start it. This is a known issue.
+* `python server.py [--host Host] [-p Port]`,
+        Host and Port are optional (defaults are `0.0.0.0:6317`)
+* `python server.py --help` for detailed usage
+
+
+**Running a client**
+
+* `python client.py [--host Host] [-p Port] first_name last_name`,
+        where `Host` and `Port` are those of the server.
+        By default `Host` is `localhost`, `Port` is 6317,
+        so it's safe to ommit them if you're running server locally.
+* type `python client.py --help` for detailed usage information.

--- a/client.py
+++ b/client.py
@@ -5,6 +5,7 @@ import time
 import json
 from collections import defaultdict
 import pygame
+import argparse
 import pygame.locals
 from player import Player
 from position import Position
@@ -178,7 +179,7 @@ class Client(MastermindClientTCP): # extends MastermindClientTCP
         for textbox in self.textboxes: #draw the textboxes
             textbox.draw()
 
-    def __init__(self):
+    def __init__(self, first_name, last_name):
         MastermindClientTCP.__init__(self)
         pygame.init()
         pygame.display.set_caption('Cataclysm: Looming Darkness')
@@ -187,11 +188,7 @@ class Client(MastermindClientTCP): # extends MastermindClientTCP
         self.ItemManager = ItemManager()
         self.RecipeManager = RecipeManager() # contains all the known recipes in the game. for reference.
         self.FontManager = FontManager()
-        if(sys.argv[1] is None):
-            print('please start the client with a first and last name for your character.')
-            print('python3 ./client John Doe')
-            exit()
-        self.player = Player(str(sys.argv[1]) + str(sys.argv[2])) # recieves updates from server. the player and all it's stats. #TODO: name and password.
+        self.player = Player(str(first_name) + str(last_name)) # recieves updates from server. the player and all it's stats. #TODO: name and password.
         self.localmap = None
         self.hotbars = []
         self.hotbars.insert(0, Hotbar(self.screen, 10, 10))
@@ -428,14 +425,22 @@ class Client(MastermindClientTCP): # extends MastermindClientTCP
             pass
 
 
+#
+#   if we start a client directly
+#
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Cataclysm LD',
+                                     epilog="Please start the client with a first and last name for your character.")
+    parser.add_argument('--host', metavar='Host', help='Server host', default='localhost')
+    parser.add_argument('-p', '--port', metavar='Port', type=int, help='Server port', default=6317)
+    parser.add_argument('first_name', help='Player\'s first name')
+    parser.add_argument('last_name', help='Player\'s last name')
 
+    args = parser.parse_args()
+    ip = args.host
+    port = args.port
 
-
-
-if __name__ == "__main__": # if we start a client directly
-    ip = '162.211.66.247'
-    port = 6317
-    client = Client()
+    client = Client(args.first_name, args.last_name)
     client.connect(ip, port)
     command = Command(client.player.name, 'login', ['password'])
     client.send(command)

--- a/server.py
+++ b/server.py
@@ -3,6 +3,8 @@ import random
 import json
 import time
 from collections import defaultdict
+import argparse
+
 from Mastermind import MastermindServerTCP
 
 from options import Options
@@ -29,8 +31,13 @@ class OverMap: # when the player pulls up the OverMap. a OverMap for each player
         return
 
 
-ip = "localhost"
-port = 6317
+parser = argparse.ArgumentParser(description='Cataclysm LD Server')
+parser.add_argument('--host', metavar='Host', help='Server host', default='0.0.0.0')
+parser.add_argument('-p', '--port', metavar='Port', type=int, help='Server port', default=6317)
+
+args = parser.parse_args()
+ip = args.host
+port = args.port
 
 ClassServer = MastermindServerTCP
 


### PR DESCRIPTION
**Running a server**

* `python server.py [--host Host] [-p Port]`,
        Host and Port are optional (defaults are `0.0.0.0:6317`)
* `python server.py --help` for detailed usage


**Running a client**

* `python client.py [--host Host] [-p Port] first_name last_name`,
        where `Host` and `Port` are those of the server.
        By default `Host` is `localhost`, `Port` is 6317,
        so it's safe to ommit them if you're running server locally.
* type `python client.py --help` for detailed usage information.